### PR TITLE
update sodium-native to v2.0.0 for latest prebuilds

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "sodium-chloride": "^1.1.0"
   },
   "optionalDependencies": {
-    "sodium-native": "^1.10.0"
+    "sodium-native": "^2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This seems to work fine in patchwork! Adds prebuilds for latest versions of electron and node.

fixes https://github.com/ssbc/scuttlebot/issues/449

cc @dominictarr 

