### PR TITLE
Upgrade sodium-native dependency to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "sodium-chloride": "^1.1.2"
   },
   "optionalDependencies": {
-    "sodium-native": "^2.1.6"
+    "sodium-native": "^2.3.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is needed for Electron 4 prebuilt binaries.