### PR TITLE
Fix 'return' outside of function

### DIFF
--- a/small.js
+++ b/small.js
@@ -1,12 +1,11 @@
-
-if(process.env.CHLORIDE_JS)
-  return module.exports = require('./browser-small')
-
-try {
-  module.exports = require('./bindings')
-} catch (err) {
-  console.error('error loading sodium bindings:', err.message)
-  console.error('falling back to javascript version.')
+if (process.env.CHLORIDE_JS) {
   module.exports = require('./browser-small')
+} else {
+  try {
+    module.exports = require('./bindings')
+  } catch (err) {
+    console.error('error loading sodium bindings:', err.message)
+    console.error('falling back to javascript version.')
+    module.exports = require('./browser-small')
+  }
 }
-


### PR DESCRIPTION
This resolves an issue where the module wasn't able to be parsed in strict mode.

See: https://github.com/ssbc/ssb-server/issues/683