### PR TITLE
Upgrade sodium-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "sodium-chloride": "^1.1.2"
   },
   "optionalDependencies": {
-    "sodium-native": "^2.1.6"
+    "sodium-native": "^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Problem: sodium-native has released a new major version and it's great
to stay up-to-date with our upstream dependencies.

Solution: Upgrade it. It seems that the breaking change is "Removed
object instance apis and replaced them with init, update, final
methods", but that doesn't seem to apply to us (?) as `npm test`
continues to pass without problems.