### PR TITLE
remove unused is-electron dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "main": "index.js",
   "browser": "browser.js",
   "dependencies": {
-    "is-electron": "^2.2.0",
     "sodium-browserify": "^1.2.7",
     "sodium-browserify-tweetnacl": "^0.2.5",
     "sodium-chloride": "^1.1.2"


### PR DESCRIPTION
I missed the `is-electron` dependency in https://github.com/ssb-js/chloride/pull/23