### PR TITLE
If falling back to JavaScript, don't emit errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ if(process.env.CHLORIDE_JS) {
   try {
     module.exports = require('./bindings')
   } catch (err) {
-    console.error('error loading sodium bindings:', err.message)
-    console.error('falling back to javascript version.')
+    console.log('error loading sodium bindings:', err.message)
+    console.log('falling back to javascript version.')
     module.exports = require('./browser')
   }
 }

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ if(process.env.CHLORIDE_JS) {
   try {
     module.exports = require('./bindings')
   } catch (err) {
-    console.log('error loading sodium bindings:', err.message)
-    console.log('falling back to javascript version.')
+    console.warn('error loading sodium bindings:', err.message)
+    console.warn('falling back to javascript version.')
     module.exports = require('./browser')
   }
 }

--- a/small.js
+++ b/small.js
@@ -4,8 +4,8 @@ if (process.env.CHLORIDE_JS) {
   try {
     module.exports = require('./bindings')
   } catch (err) {
-    console.error('error loading sodium bindings:', err.message)
-    console.error('falling back to javascript version.')
+    console.log('error loading sodium bindings:', err.message)
+    console.log('falling back to javascript version.')
     module.exports = require('./browser-small')
   }
 }

--- a/small.js
+++ b/small.js
@@ -4,8 +4,8 @@ if (process.env.CHLORIDE_JS) {
   try {
     module.exports = require('./bindings')
   } catch (err) {
-    console.log('error loading sodium bindings:', err.message)
-    console.log('falling back to javascript version.')
+    console.warn('error loading sodium bindings:', err.message)
+    console.warn('falling back to javascript version.')
     module.exports = require('./browser-small')
   }
 }


### PR DESCRIPTION
Instead of emitting errors, emit log messages.  Mainly because if we're in a browser (ssb-browser-demo), with these emitting errors it means every time the page loads it starts right off with two error messages.